### PR TITLE
fix(ci): postgres-shaped dummy DATABASE_URL for the build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     quality:
         runs-on: ubuntu-latest
         env:
-            DATABASE_URL: https://example.com
+            DATABASE_URL: postgresql://ci:ci@localhost:5432/ci
             BETTER_AUTH_URL: http://localhost:3000
             BETTER_AUTH_SECRET: ci-build-secret-ci-build-secret-ci-build-secret
 


### PR DESCRIPTION
## Summary
CI has failed on master for weeks: `https://example.com` satisfies the zod `.url()` env check but `neon()` rejects a non-postgres connection string when `src/server/db/connection.ts` is imported during Next's page-data collection (`/api/activity/combined`). Use a well-formed dummy postgres URL — neon only parses it at import; nothing connects during build.

## Test plan
- `bun run build` with the workflow's exact env — lint, typecheck, tests, and build all pass (30.8s).

## Summary by Sourcery

Build:
- Update CI workflow environment to use a postgres-formatted DATABASE_URL instead of a generic HTTPS URL.